### PR TITLE
fix: demo for browsers without SessionStorage support

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormProvider } from './hooks/useForm'
 import { FpjsProvider } from '@fingerprintjs/fingerprintjs-pro-react'
 import * as FingerprintJS from '@fingerprintjs/fingerprintjs-pro'
+import { CacheLocation } from '@fingerprintjs/fingerprintjs-pro-spa'
 import { GithubProvider } from './context/GithubContext'
 import { BotdProvider } from './context/BotdContext'
 import { HistoryListener } from './context/HistoryListener'
@@ -73,6 +74,7 @@ function AppLighthouseProvider({ children }: { children: React.ReactNode }) {
           region,
           scriptUrlPattern,
         }}
+        cacheLocation={CacheLocation.NoCache}
       >
         {children}
       </FpjsProvider>


### PR DESCRIPTION
The `SessionStorage` is not available in some browsers which breaks demo for some users. Fingerprint Pro React lib [uses](https://github.com/fingerprintjs/fingerprintjs-pro-react#caching-strategy) the `SessionStorage` as a default caching strategy.

Please note, I'm not fully familiar with this website and the recommended fix needs a proper review and testing since I don't know if something relies on this cache (I was not able to find anything).